### PR TITLE
Some improvement and bug fix.

### DIFF
--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -88,14 +88,13 @@ export class Detector {
         let detectString: string = processedText;
         let regSpace: RegExp = /\s+/;
         let array: string[] = detectString.trim().split(regSpace);
-        detectString = array.join("");
-        detectString = this.removePunctuationAndDigit(detectString);
+        let words = array.map(str => this.removePunctuationAndDigit(str));
         let regWord: RegExp = /^[a-zA-Z]+$/;
-
-        if (regWord.test(detectString)) {
-          if (processedText !== undefined && processedText !== "") {
-            console.log("Hardcoded string found: " + processedText);
-            isBroken = true;
+        for (let word of words) {
+          if (regWord.test(word) && processedText){
+              console.log("Hardcoded string found: " + processedText);
+              isBroken = true;
+              break;
           }
         }
       }

--- a/src/lib/glob-auto-lib.ts
+++ b/src/lib/glob-auto-lib.ts
@@ -46,7 +46,7 @@ export async function checkerRun(selector: string, lang: string, checks: GalChec
   try {
     let issues: ICreateIssue[] = [];
 
-    await element.all(by.xpath(selector + "//*[not(descendant::div)]")).each(async elem => {
+    await element.all(by.xpath(selector + "//*[normalize-space(text())]")).each(async elem => {
       try {
         for (let check of checks) {
           let result: boolean = false;

--- a/src/lib/issueHelper.ts
+++ b/src/lib/issueHelper.ts
@@ -173,10 +173,10 @@ export function FilterIssues(issues: ICreateIssue[]): ICreateIssue[] {
   }
 
   for (let i: number = 0; i < n; i++) {
-    for (let j: number = 0; j < n; j++) {
+    for (let j: number = i + 1; j < n; j++) {
 
       // is i inside j inside
-      if (i !== j && issues[i].type === issues[j].type) {
+      if ( issues[i].type === issues[j].type) {
         if (!inside[i]) {
           inside[i] = IsInside(issues[i].x,
             issues[i].y,
@@ -201,9 +201,6 @@ export function FilterIssues(issues: ICreateIssue[]): ICreateIssue[] {
             issues[i].width,
             issues[i].height);
 
-          if (inside[j]) {
-            break;
-          }
         }
       }
     }


### PR DESCRIPTION
Improvement:
  Select only non-empty text nodes elements to run checkers against.

Issues Fix:
  1) Change HardCode checker to check string against every space delimited word.
     element.getText() return text not only from current text node but also
     text from child nodes, the old checker will miss any hard code string from child text nodes.
  2) Issues filter doesn't work properly, in some cases,  all the issues will be filtered out.
     For example, detected issues A, B share the same x,y,w,h. A is inside B and B is also
     inside A, both of them will be marked as "inside" to be filtered out.