### PR TITLE
Fix bug in issue filter, add test for issue filter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "glob-auto-library",
-	"version": "1.1.17",
+	"version": "1.1.18",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
 		"typescript": "^3.3.3",
 		"webpack": "^4.29.5",
 		"webpack-cli": "^3.2.3",
-		"webpack-node-externals": "^1.7.2"
+		"webpack-node-externals": "^1.7.2",
+		"xmldom": "^0.1.27",
+		"xpath": "0.0.27"
 	},
 	"engines": {
 		"node": ">=6.9.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "glob-auto-library",
-	"version": "1.1.17",
+	"version": "1.1.18",
 	"description": "Globalization Automation Library",
 	"license": "MIT",
 	"main": "lib/lib.js",

--- a/src/lib/glob-auto-lib.ts
+++ b/src/lib/glob-auto-lib.ts
@@ -46,7 +46,7 @@ export async function checkerRun(selector: string, lang: string, checks: GalChec
   try {
     let issues: ICreateIssue[] = [];
 
-    await element.all(by.xpath(selector + "//*[not(descendant::div)]")).each(async elem => {
+    await element.all(by.xpath(selector + "//*[normalize-space(text())]")).each(async elem => {
       try {
         for (let check of checks) {
           let result: boolean = false;

--- a/src/lib/issueHelper.ts
+++ b/src/lib/issueHelper.ts
@@ -173,10 +173,10 @@ export function FilterIssues(issues: ICreateIssue[]): ICreateIssue[] {
   }
 
   for (let i: number = 0; i < n; i++) {
-    for (let j: number = 0; j < n; j++) {
+    for (let j: number = i + 1; j < n; j++) {
 
       // is i inside j inside
-      if (i !== j && issues[i].type === issues[j].type) {
+      if ( issues[i].type === issues[j].type) {
         if (!inside[i]) {
           inside[i] = IsInside(issues[i].x,
             issues[i].y,
@@ -201,9 +201,6 @@ export function FilterIssues(issues: ICreateIssue[]): ICreateIssue[] {
             issues[i].width,
             issues[i].height);
 
-          if (inside[j]) {
-            break;
-          }
         }
       }
     }

--- a/tests/issuefilter.test.ts
+++ b/tests/issuefilter.test.ts
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2019 Veritas Technologies LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { FilterIssues } from "../src/lib/issueHelper";
+import { ICreateIssue } from "../src/arp/utils/garb-interface";
+
+
+let duplicate_same_type = `[
+{"severity":2,"identifier":"1","text":"User 'root' is logged out","type":1,"status":0,"x":1288,"y":646,"width":188,"height":23},
+{"severity":2,"identifier":"2","text":"User 'root' is logged out","type":1,"status":0,"x":1288,"y":646,"width":188,"height":23},
+{"severity":2,"identifier":"3","text":"User 'root' is logged out","type":1,"status":0,"x":1288,"y":646,"width":188,"height":23}
+]`;
+
+let different_type_same_position = `[
+{"severity":2,"identifier":"1","text":"User 'root' is logged out","type":1,"status":0,"x":1288,"y":646,"width":188,"height":23},
+{"severity":2,"identifier":"2","text":"User 'root' is logged out","type":2,"status":0,"x":1288,"y":646,"width":188,"height":23},
+{"severity":2,"identifier":"3","text":"User 'root' is logged out","type":3,"status":0,"x":1288,"y":646,"width":188,"height":23}
+]`;
+
+let nested =`[
+{"severity":2,"identifier":"medium","text":"User 'root' is logged out","type":1,"status":0,"x":1287,"y":645,"width":186,"height":21},
+{"severity":2,"identifier":"small","text":"User 'root' is logged out","type":1,"status":0,"x":1288,"y":646,"width":185,"height":20},
+{"severity":2,"identifier":"large","text":"User 'root' is logged out","type":1,"status":0,"x":1286,"y":644,"width":187,"height":22}
+]`;
+
+let one_inside_other_two =`[
+{"severity":2,"identifier":"outside_1","text":"User 'root' is logged out","type":1,"status":0,"x":1193,"y":540,"width":360,"height":134},
+{"severity":2,"identifier":"outside_2","text":"User 'root' is logged out","type":1,"status":0,"x":1298,"y":494,"width":334,"height":147},
+{"severity":2,"identifier":"inside","text":"User 'root' is logged out","type":1,"status":0,"x":1338,"y":564,"width":180,"height":63}
+]`;
+
+let two_inside_one =`[
+{"severity":2,"identifier":"inside_1","text":"User 'root' is logged out","type":1,"status":0,"x":1338,"y":564,"width":180,"height":63},
+{"severity":2,"identifier":"outside","text":"User 'root' is logged out","type":1,"status":0,"x":1193,"y":540,"width":360,"height":134},
+{"severity":2,"identifier":"inside_2","text":"User 'root' is logged out","type":1,"status":0,"x":1217,"y":567,"width":103,"height":65}
+]`;
+
+
+
+describe("issue filter", () => {
+
+  it("Three Duplicated same type issues", () => {
+    let issues: ICreateIssue[];
+	issues = JSON.parse(duplicate_same_type);
+    let filtered: ICreateIssue[] = FilterIssues(issues)
+	expect(filtered.length).toBe(1);
+  });
+
+  it("Three different type issues on same position", () => {
+    let issues: ICreateIssue[];
+	issues = JSON.parse(different_type_same_position);
+    let filtered: ICreateIssue[] = FilterIssues(issues)
+	expect(filtered.length).toBe(3);
+  });
+
+  it("Three same type issues with nested position", () => {
+    let issues: ICreateIssue[];
+	issues = JSON.parse(nested);
+    let filtered: ICreateIssue[] = FilterIssues(issues)
+	expect(filtered.length).toBe(1);
+  });
+
+  it("One issue inside both two other issues", () => {
+    let issues: ICreateIssue[];
+	issues = JSON.parse(one_inside_other_two);
+    let filtered: ICreateIssue[] = FilterIssues(issues)
+	expect(filtered.length).toBe(2);
+  });
+
+  it("Two issues inside one issue", () => {
+    let issues: ICreateIssue[];
+	issues = JSON.parse(two_inside_one);
+    let filtered: ICreateIssue[] = FilterIssues(issues)
+	expect(filtered.length).toBe(1);
+  });
+
+
+});

--- a/tests/selector.test.ts
+++ b/tests/selector.test.ts
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2019 Veritas Technologies LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { Detector } from "../src/lib/detector";
+import { DOMParser as dom } from 'xmldom';
+
+var xpath = require('xpath');
+
+const xml = `<div><table><tr><td><span>It's English text</span></td></tr></table></div>`;
+const test_doc =  new dom().parseFromString(xml);
+const xpath_orig = "//*[not(descendant::div)]";
+const xpath_mod = "//*[normalize-space(text())]";
+
+describe("xpath selector test", () => {
+
+  function runSelectorTest(selector: string, doc: any, expected: number){
+    console.log(`\nxpath selector: "${selector}"`);
+    let nodes = xpath.select(selector, doc);
+    let count = 0;
+    for (let node of nodes){
+      let str = xpath.select('string()',node)
+      let result: boolean = Detector.IsHardcode(str);
+      expect(result).toBe(true);
+      count ++;
+    }
+    expect(count).toBe(expected);
+    console.log(`${count} hard code string issues found\n`)!
+  };
+
+  it(`${xpath_orig} selector should detect 5 hard code issues`, () => {
+    runSelectorTest(xpath_orig, test_doc, 5);
+  });
+
+  it(`${xpath_mod} selector should detect only 1 hard code issues`, () => {
+    runSelectorTest(xpath_mod, test_doc, 1);
+  });
+
+});


### PR DESCRIPTION
1) Fix bug in issue filter, add test for issue filter.  
   Issues filter doesn't work properly in some cases, duplicated issues with be all filtered out.
   For example, detected issues A, B share the same x,y,w,h. A is inside B and B is also
   inside A, both of them will be marked as "inside" and filtered out.

2) Improve performance by selecting only non-empty text nodes to run checkers against.